### PR TITLE
changed order of ssl.wrap_socket. Had to init it first before calling it

### DIFF
--- a/starter_projects/lib/networking/mqtt_client/mqtt_client.py
+++ b/starter_projects/lib/networking/mqtt_client/mqtt_client.py
@@ -75,11 +75,11 @@ class MQTTClient:
         self.sock = socket.socket()
         self.sock.setblocking(True)
         addr = socket.getaddrinfo(self.server, self.port)[0][-1]
+        self.sock.connect(addr)
         if self.ssl:
             import ssl
 
             self.sock = ssl.wrap_socket(self.sock, **self.ssl_params)
-        self.sock.connect(addr)
         premsg = bytearray(b"\x10\0\0\0\0\0")
         msg = bytearray(b"\x04MQTT\x04\x02\0\0")
 


### PR DESCRIPTION
I was trying to connect to AWS using MQTT and the sample provided, but the mqtt_client.py file has an error. It does not initialize the socket before doing the wrap. That gave an unknown error.  